### PR TITLE
Handle lambda scope using `Scope` class

### DIFF
--- a/cpp/common/src/codingstandards/cpp/rules/identifierhidden/IdentifierHidden.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/identifierhidden/IdentifierHidden.qll
@@ -41,7 +41,7 @@ predicate hiddenInLambda(UserVariable outerDecl, UserVariable innerDecl) {
     outerScope.getADeclaration() = outerDecl and
     lambdaExprScope.getStrictParent*() = outerScope and
     (
-      // A definition can be hidden if it is in scope and it iscaptured by the lambda,
+      // A definition can be hidden if it is in scope and it is captured by the lambda,
       exists(LambdaCapture cap |
         lambdaExpr.getACapture() = cap and
         // The outer declaration is captured by the lambda

--- a/cpp/common/test/rules/identifierhidden/IdentifierHidden.expected
+++ b/cpp/common/test/rules/identifierhidden/IdentifierHidden.expected
@@ -11,3 +11,7 @@
 | test.cpp:81:5:81:5 | a | Declaration is hiding declaration $@. | test.cpp:79:5:79:5 | a | a |
 | test.cpp:102:9:102:9 | b | Declaration is hiding declaration $@. | test.cpp:96:11:96:11 | b | b |
 | test.cpp:114:9:114:17 | globalvar | Declaration is hiding declaration $@. | test.cpp:110:5:110:13 | globalvar | globalvar |
+| test.cpp:133:11:133:11 | b | Declaration is hiding declaration $@. | test.cpp:127:13:127:13 | b | b |
+| test.cpp:142:9:142:10 | a1 | Declaration is hiding declaration $@. | test.cpp:140:14:140:15 | a1 | a1 |
+| test.cpp:147:9:147:10 | a2 | Declaration is hiding declaration $@. | test.cpp:145:20:145:21 | a2 | a2 |
+| test.cpp:152:9:152:10 | a3 | Declaration is hiding declaration $@. | test.cpp:150:17:150:18 | a3 | a3 |

--- a/cpp/common/test/rules/identifierhidden/test.cpp
+++ b/cpp/common/test/rules/identifierhidden/test.cpp
@@ -120,3 +120,64 @@ int f6() {
 
   return lambda_with_shadowing();
 }
+
+void f7(int p) {
+  // Introduce a nested scope to test scope comparison.
+  if (p != 0) {
+    int a1, b;
+    auto lambda1 = [a1]() {
+      int b = 10; // COMPLIANT - exception - non captured variable b
+    };
+
+    auto lambda2 = [b]() {
+      int b = 10; // NON_COMPLIANT - not an exception - captured
+                  // variable b
+    };
+  }
+}
+
+void f8() {
+  static int a1;
+  auto lambda1 = []() {
+    int a1 = 10; // NON_COMPLIANT - Lambda can access static variable.
+  };
+
+  thread_local int a2;
+  auto lambda2 = []() {
+    int a2 = 10; // NON_COMPLIANT - Lambda can access thread local variable.
+  };
+
+  constexpr int a3 = 10;
+  auto lambda3 = []() {
+    int a3 = a3 + 1; // NON_COMPLIANT - Lambda can access const
+                     // expression without mutable members.
+  };
+
+  const int &a4 = a3;
+  auto lambda4 = []() {
+    int a4 = a4 + 1; // NON_COMPLIANT[FALSE_NEGATIVE] - Lambda can access
+                     // reference initialized with constant expression.
+  };
+
+  const int a5 = 10;
+  auto lambda5 = []() {
+    int a5 = a5 + 1; // NON_COMPLIANT[FALSE_NEGATIVE] - Lambda can access const
+                     // non-volatile integral or enumeration type initialized
+                     // with constant expression.
+  };
+
+  volatile const int a6 = 10;
+  auto lambda6 = []() {
+    int a6 =
+        a6 + 1; // COMPLIANT - Lambda cannot access const volatile integral or
+                // enumeration type initialized with constant expression.
+  };
+}
+
+void f9() {
+  auto lambda1 = []() {
+    int a1 = 10; // COMPLIANT
+  };
+
+  int a1 = 10;
+}


### PR DESCRIPTION
Handle the scope using the `Scope` class to reason about arbitrary lambda expression scopes, not just withing the scope of the function body.

I've added test cases for the non-capture situations and there are false negatives we need solve.